### PR TITLE
Drop `openff-units` dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@
 The `pydantic-units` framework aims to offer a convenient way to work with OpenMM units
 in Pydantic models, in a way that is backwards compatible with both Pydantic v1 and v2.
 
+It is lightweight and has no dependencies beyond Pydantic and OpenMM. All units that
+are available in OpenMM are supported except for `'ampere'` whose symbol is `'A'`,
+which conflicts with the angstrom unit symbol.
+
 ## Installation
 
 This package can be installed using `conda` (or `mamba`, a faster version of `conda`):
@@ -53,7 +57,7 @@ class Model(BaseModel):
 
 model = Model(a='1.0 angstrom', b='1.0 nm')
 model.json()
-# '{"a": "1.0 angstrom", "b": "1.0 nm"}'
+# '{"a": "1 A", "b": "1.0 nm"}'
 ```
 
 ### Pydantic V2
@@ -63,39 +67,85 @@ can be used directly in the model:
 
 ```python
 from pydantic import BaseModel
-from openmm.unit import angstrom, nanometer
+from openmm import unit
 
 from pydantic_units import OpenMMQuantity
 
 class Model(BaseModel):
-    a: OpenMMQuantity[angstrom]
-    b: OpenMMQuantity[nanometer]
+    a: OpenMMQuantity[unit.angstrom]
+    b: OpenMMQuantity[unit.nanometer]
 
 model = Model(a='1.0 angstrom', b='1.0 nm')
 # OR
-model = Model(a=1.0 * angstrom, b=1.0 * nanometer)
+model = Model(a=1.0 * unit.angstrom, b=1.0 * unit.nanometer)
 
 model.model_dump_json()
-# '{"a": "1.0 angstrom", "b": "1.0 nm"}'
+# '{"a": "1 A", "b": "1.0 nm"}'
 ```
 
 Backwards compatibility with Pydantic v1 is also maintained:
 
 ```python
 from pydantic.v1 import BaseModel
-from openmm.unit import Quantity, angstrom, nanometer
+from openmm import unit
 
 from pydantic_units import quantity_serializer
 from pydantic_units.v1 import OpenMMQuantity
 
 class Model(BaseModel):
     class Config:
-        json_encoders = {Quantity: quantity_serializer}
+        json_encoders = {unit.Quantity: quantity_serializer}
 
-    a: OpenMMQuantity[angstrom]
-    b: OpenMMQuantity[nanometer]
+    a: OpenMMQuantity[unit.angstrom]
+    b: OpenMMQuantity[unit.nanometer]
 
 model = Model(a='1.0 angstrom', b='1.0 nm')
 model.json()
-# '{"a": "1.0 angstrom", "b": "1.0 nm"}'
+# '{"a": "1 A", "b": "1.0 nm"}'
+```
+
+### (De)Serialization
+
+Quantity fields will be serialized into JSON as strings with the unit symbol, e.g.
+
+```python
+from pydantic_units import quantity_serializer
+from openmm import unit
+
+print(quantity_serializer(1.0 * unit.angstrom))
+# '1 A'
+print(quantity_serializer(1.0 * unit.kilojoules_per_mole))
+# '1.0 kJ * mol**-1'
+```
+
+Likewise, when instantiating a field from a string (either through the constructor or
+through parsing JSON), the unit should be specified in the string as either the full
+unit name or the unit symbol:
+
+```python
+from pydantic_units import quantity_validator
+from openmm import unit
+
+print(quantity_validator('1.0 angstrom', unit.angstrom))
+# 1.0 A
+print(quantity_validator('1.0 A', unit.angstrom))
+# 1.0 A
+print(quantity_validator('1.0 kJ/mol', unit.kilojoules_per_mole))
+# 1.0 kJ/mol
+```
+
+The leading `*` can be either included or omitted, and whitespace is usually ignored:
+
+```python
+from pydantic_units import quantity_validator
+from openmm import unit
+
+print(quantity_validator('1.0 A', unit.angstrom))
+# 1.0 A
+print(quantity_validator('1.0A', unit.angstrom))
+# 1.0 A
+print(quantity_validator('1.0 * A', unit.angstrom))
+# 1.0 A
+print(quantity_validator('1.0*A', unit.angstrom))
+# 1.0 A
 ```

--- a/devtools/envs/base.yaml
+++ b/devtools/envs/base.yaml
@@ -9,9 +9,7 @@ dependencies:
   - pip
 
   - pydantic
-
   - openmm
-  - openff-units
 
   # Dev / Testing
   - setuptools_scm >=8

--- a/pydantic_units/__init__.py
+++ b/pydantic_units/__init__.py
@@ -4,7 +4,7 @@ import importlib.metadata
 
 import pydantic
 
-from ._common import quantity_serializer
+from ._common import quantity_serializer, quantity_validator
 
 if pydantic.__version__.startswith("1."):
     from .v1 import OpenMMQuantity
@@ -16,4 +16,4 @@ try:
 except importlib.metadata.PackageNotFoundError:  # pragma: no cover
     __version__ = "0+unknown"
 
-__all__ = ["OpenMMQuantity", "__version__", "quantity_serializer"]
+__all__ = ["OpenMMQuantity", "__version__", "quantity_serializer", "quantity_validator"]

--- a/pydantic_units/tests/test_common.py
+++ b/pydantic_units/tests/test_common.py
@@ -1,0 +1,50 @@
+import pytest
+from openmm import unit
+
+from pydantic_units._common import quantity_serializer, quantity_validator
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (1.0 * unit.angstrom, "1.0 A"),
+        (1.0 * unit.angstrom**2, "1.0 A**2"),
+        (1.0 * unit.atomic_mass_unit, "1.0 Da"),
+        (1.0 * unit.kilojoules_per_mole, "1.0 kJ * mol**-1"),
+        (1.0 * unit.nanometers, "1.0 nm"),
+        (1.0 * unit.kilojoules_per_mole / unit.kelvin**2, "1.0 kJ * mol**-1 * K**-2"),
+        (1.0 * unit.dimensionless, "1.0"),
+    ],
+)
+def test_quantity_serializer(value, expected):
+    assert quantity_serializer(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("2.0 A", 2.0 * unit.angstrom),
+        ("2.0 angstrom", 2.0 * unit.angstrom),
+        ("2.0 kJ/mole", 2.0 * unit.kilojoules_per_mole),
+        ("2.0 * A", 2.0 * unit.angstrom),
+        ("-2.0 / A", -2.0 / unit.angstrom),
+        ("-2.0 A", -2.0 * unit.angstrom),
+        ("3.0A**2", 3.0 * unit.angstrom**2),
+        ("4.0(kcal/(mol*A**2))", 4.0 * unit.kilocalorie_per_mole / unit.angstrom**2),
+        ("5.0  amu", 5.0 * unit.atomic_mass_unit),
+        ("   5.0*amu    ", 5.0 * unit.atomic_mass_unit),
+    ],
+)
+def test_quantity_validator(value, expected):
+    actual = quantity_validator(value, expected.unit)
+
+    assert actual.unit == expected.unit
+
+    assert actual.value_in_unit_system(unit.md_unit_system) == pytest.approx(
+        expected.value_in_unit_system(unit.md_unit_system)
+    )
+
+
+def test_quantity_validator_bad_unit():
+    with pytest.raises(KeyError, match="unit could not be found"):
+        quantity_validator("1.0 * ampere", unit.ampere)

--- a/pydantic_units/tests/test_pydantic_units.py
+++ b/pydantic_units/tests/test_pydantic_units.py
@@ -11,7 +11,7 @@ def test_pydantic_units():
 
 def _validate_v1_model(model, model_cls):
     model_json = model.json()
-    assert model_json == '{"a": "1.00000000 angstrom", "b": "0.10000000 nanometer"}'
+    assert model_json == '{"a": "1 A", "b": "0.1 nm"}'
 
     model_schema = model.schema()
     assert model_schema == {
@@ -82,7 +82,7 @@ def test_v2():
     model = Model(a=1 * angstrom, b=1 * angstrom)
 
     model_json = model.model_dump_json()
-    assert model_json == '{"a":"1.00000000 angstrom","b":"0.10000000 nanometer"}'
+    assert model_json == '{"a":"1 A","b":"0.1 nm"}'
 
     model_schema = model.model_json_schema()
     assert model_schema == {
@@ -113,7 +113,7 @@ def test_invalid_units():
         a: OpenMMQuantity[angstrom]
 
     with pytest.raises(pydantic.ValidationError):
-        Model(a=1 * kelvin)
+        Model(a=1.0 * kelvin)
 
     with pytest.raises(pydantic.ValidationError):
         Model.model_validate_json('{"a":"1.00000000 kelvin"}')


### PR DESCRIPTION
## Description

This PR removes the extra `openff-units` dependency, and allows more permissive ways of writing units. This includes using just symbols, and removing extra '*' signs for compactness.

## Status
- [X] Ready to go
