### PR TITLE
Add names to CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    name: Test
 
     runs-on: ubuntu-latest
     container: condaforge/mambaforge:latest

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   deploy-docs:
+    name: Deploy Documentation
 
     runs-on: ubuntu-latest
     container: condaforge/mambaforge:latest
@@ -44,8 +45,8 @@ jobs:
         git fetch --all --prune
 
         make env
-        
+
         sed -i 's/# extensions/extensions/' mkdocs.yml
         make docs-insiders INSIDER_DOCS_TOKEN="${INSIDER_DOCS_TOKEN}"
-        
+
         make docs-deploy VERSION="$VERSION"


### PR DESCRIPTION
## Description

This PR adds names to the CI checks. Currently they don't show under branch protections, and this hopefully resolves that.

## Status
- [X] Ready to go
