### PR TITLE
Improve docs and support "Å"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@
 
 The `pydantic-units` framework aims to offer a convenient way to work with OpenMM units
 in Pydantic models, in a way that is backwards compatible with both Pydantic v1 and v2.
+It is lightweight and has no dependencies beyond Pydantic and OpenMM.
 
-It is lightweight and has no dependencies beyond Pydantic and OpenMM. All units that
-are available in OpenMM are supported except for `'ampere'` whose symbol is `'A'`,
-which conflicts with the angstrom unit symbol.
+All units that are available in OpenMM are supported except for `'ampere'` whose symbol
+conflicts with the angstrom unit symbol, making parsing ambiguous. Angstroms can be
+specified as either `'A'`, or `'Å'`.
 
 ## Installation
 
@@ -37,6 +38,35 @@ The `OpenMMQuantity` class can be used as a field in a Pydantic model to represe
 quantity with units. It will both handle parsing quantities with units from strings and
 checking that parsed units are compatible with the expected units.
 
+Quantities can either be passed into models (see below for how to define models) with
+such a field directly:
+
+```python
+from openmm import unit
+MyModel(temperature=300.0 * unit.kelvin)
+```
+
+or they can be passed in as strings, in which case the unit can be specified either
+fully
+
+```python
+MyModel(temperature='300.0 kelvin')
+```
+
+or with the unit symbol
+
+```python
+MyModel(temperature='300.0 K')
+```
+
+The field also handles validation of the unit, so that the following will raise a
+validation error:
+
+```python
+MyModel(temperature='300.0 A')
+# raises: Value error, invalid units angstrom - expected angstrom kelvin
+```
+
 ### Pydantic V1
 
 Due to limitations of custom fields in Pydantic v1, v1 models must define a custom
@@ -44,26 +74,26 @@ JSON encoder if the model needs to be serialised to JSON:
 
 ```python
 from pydantic import BaseModel
-from openmm.unit import Quantity, angstrom, nanometer
+from openmm import unit
 
 from pydantic_units import OpenMMQuantity, quantity_serializer
 
 class Model(BaseModel):
     class Config:
-        json_encoders = {Quantity: quantity_serializer}
+        json_encoders = {unit.Quantity: quantity_serializer}
 
-    a: OpenMMQuantity[angstrom]
-    b: OpenMMQuantity[nanometer]
+    a: OpenMMQuantity[unit.angstrom]
+    b: OpenMMQuantity[unit.kelvin]
 
-model = Model(a='1.0 angstrom', b='1.0 nm')
+model = Model(a=1.0 * unit.nanometer, b='298.0 K')
 model.json()
-# '{"a": "1 A", "b": "1.0 nm"}'
+# '{"a": "10.0 A", "b": "298.0 K"}'
 ```
 
 ### Pydantic V2
 
 Pydantic v2 supports custom fields with custom encoders, so the `OpenMMQuantity` field
-can be used directly in the model:
+can be used directly in the model without needing to define a custom JSON encoder:
 
 ```python
 from pydantic import BaseModel
@@ -73,14 +103,11 @@ from pydantic_units import OpenMMQuantity
 
 class Model(BaseModel):
     a: OpenMMQuantity[unit.angstrom]
-    b: OpenMMQuantity[unit.nanometer]
+    b: OpenMMQuantity[unit.kelvin]
 
-model = Model(a='1.0 angstrom', b='1.0 nm')
-# OR
-model = Model(a=1.0 * unit.angstrom, b=1.0 * unit.nanometer)
-
+model = Model(a=1.0 * unit.nanometer, b='298.0 K')
 model.model_dump_json()
-# '{"a": "1 A", "b": "1.0 nm"}'
+# '{"a": "10.0 A", "b": "298.0 K"}'
 ```
 
 Backwards compatibility with Pydantic v1 is also maintained:
@@ -97,11 +124,11 @@ class Model(BaseModel):
         json_encoders = {unit.Quantity: quantity_serializer}
 
     a: OpenMMQuantity[unit.angstrom]
-    b: OpenMMQuantity[unit.nanometer]
+    b: OpenMMQuantity[unit.kelvin]
 
-model = Model(a='1.0 angstrom', b='1.0 nm')
+model = Model(a=1.0 * unit.nanometer, b='298.0 K')
 model.json()
-# '{"a": "1 A", "b": "1.0 nm"}'
+# '{"a": "10.0 A", "b": "298.0 K"}'
 ```
 
 ### (De)Serialization
@@ -126,26 +153,23 @@ unit name or the unit symbol:
 from pydantic_units import quantity_validator
 from openmm import unit
 
-print(quantity_validator('1.0 angstrom', unit.angstrom))
-# 1.0 A
-print(quantity_validator('1.0 A', unit.angstrom))
-# 1.0 A
-print(quantity_validator('1.0 kJ/mol', unit.kilojoules_per_mole))
-# 1.0 kJ/mol
+quantity_validator('1.0 angstrom', unit.angstrom)
+# Quantity(value=1.0, unit=angstrom)
+quantity_validator('1.0 A', unit.angstrom)
+# Quantity(value=1.0, unit=angstrom)
+quantity_validator('1.0 kJ/mol', unit.kilojoules_per_mole)
+# Quantity(value=1.0, unit=kilojoule/mole)
 ```
 
-The leading `*` can be either included or omitted, and whitespace is usually ignored:
+The leading `*` can be either included or omitted, and whitespace is usually ignored,
+such that the following are all equivalent:
 
 ```python
 from pydantic_units import quantity_validator
 from openmm import unit
 
-print(quantity_validator('1.0 A', unit.angstrom))
-# 1.0 A
-print(quantity_validator('1.0A', unit.angstrom))
-# 1.0 A
-print(quantity_validator('1.0 * A', unit.angstrom))
-# 1.0 A
-print(quantity_validator('1.0*A', unit.angstrom))
-# 1.0 A
+quantity_validator('1.0 A', unit.angstrom)
+quantity_validator('1.0A', unit.angstrom)
+quantity_validator('1.0 * A', unit.angstrom)
+quantity_validator('1.0*A', unit.angstrom)
 ```

--- a/pydantic_units/_common.py
+++ b/pydantic_units/_common.py
@@ -19,7 +19,10 @@ for __unit in openmm.unit.__dict__.values():
         _UNIT_LOOKUP[__unit.get_name()] = __unit
 
 _UNIT_LOOKUP["amu"] = openmm.unit.atomic_mass_unit
+_UNIT_LOOKUP["Å"] = openmm.unit.angstrom
 del __unit
+
+_VALUE_REGEX = re.compile(r"^([0-9.\-+]+)[ ]*[a-zA-ZÅ(\[]")
 
 
 def _openmm_quantity_from_str(value: str) -> Quantity:
@@ -47,7 +50,7 @@ def _openmm_quantity_from_str(value: str) -> Quantity:
             raise NotImplementedError(node)
 
     value = value.strip()
-    value_match = re.match(r"^([0-9.\-+]+)[ ]*[a-zA-Z(\[]", value)
+    value_match = re.match(_VALUE_REGEX, value)
 
     if value_match:
         split_idx = value_match.regs[-1][-1]

--- a/pydantic_units/tests/test_common.py
+++ b/pydantic_units/tests/test_common.py
@@ -24,6 +24,7 @@ def test_quantity_serializer(value, expected):
     "value, expected",
     [
         ("2.0 A", 2.0 * unit.angstrom),
+        ("2.0 Å", 2.0 * unit.angstrom),
         ("2.0 angstrom", 2.0 * unit.angstrom),
         ("2.0 kJ/mole", 2.0 * unit.kilojoules_per_mole),
         ("2.0 * A", 2.0 * unit.angstrom),


### PR DESCRIPTION
## Description

This PR cleans up the main README, adding clearer examples of what is supported. It further adds support for using the "Å" symbol for angstroms.

## Status
- [X] Ready to go
